### PR TITLE
Fix lora-app-server path in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ requirements:
 
 serve: build
 	@echo "Starting Lora App Server"
-	./build/lora_app_server
+	./build/lora-app-server
 
 update-vendor:
 	@echo "Updating vendored packages"


### PR DESCRIPTION
A typo - came across this when looking into Docker files 'make serve' stanza