### PR TITLE
Expire downlink_queue items

### DIFF
--- a/internal/common/vars.go
+++ b/internal/common/vars.go
@@ -1,0 +1,11 @@
+package common
+
+import (
+	"time"
+)
+
+// TODO: move these vars to Context?
+
+// NodeTXPayloadQueueTTL defines the TTL of the node TXPayload queue
+var NodeTXPayloadQueueTTL = time.Minute * 55
+

--- a/migrations/0005_add_queue.sql
+++ b/migrations/0005_add_queue.sql
@@ -6,7 +6,8 @@ create table downlink_queue (
     confirmed boolean not null default false,
     pending boolean not null default false,
     fport smallint not null,
-    data bytea not null
+    data bytea not null,
+    date_created timestamp with time zone not null default now()
 );
 
 create index downlink_queue_dev_eui on downlink_queue(dev_eui);


### PR DESCRIPTION
I have found it useful to be able to expire downlink_queue items after a given period, as it prevents backlogs and storms. A possible simple implementation.