### PR TITLE
Fix a warning of eslint: eqeqeq rule

### DIFF
--- a/ui/src/views/nodes/ListNodes.js
+++ b/ui/src/views/nodes/ListNodes.js
@@ -13,7 +13,7 @@ class NodeRow extends Component {
     let lastseen = "n/a";
     let margin = "n/a";
     let battery = "n/a";
-    if (this.props.node.lastSeenAt !== undefined && this.props.node.lastSeenAt != "") {
+    if (this.props.node.lastSeenAt !== undefined && this.props.node.lastSeenAt !== "") {
       lastseen = moment(this.props.node.lastSeenAt).fromNow();
     }
 


### PR DESCRIPTION
Fix following warning:

> Line 16:  Expected '!==' and instead saw '!='  eqeqeq