### PR TITLE
Added support for nullable FPort

### DIFF
--- a/internal/api/application_server.go
+++ b/internal/api/application_server.go
@@ -142,9 +142,13 @@ func (a *ApplicationServerAPI) HandleUplinkData(ctx context.Context, req *as.Han
 			CodeRate: req.TxInfo.CodeRate,
 		},
 		FCnt:   req.FCnt,
-		FPort:  uint8(req.FPort),
 		Data:   b,
 		Object: object,
+	}
+
+	if req.FPort != 0 {
+		pl.FPort = new(uint8)
+		*pl.FPort = uint8(req.FPort)
 	}
 
 	for _, rxInfo := range req.RxInfo {

--- a/internal/handler/influxdbhandler/influxdb_handler.go
+++ b/internal/handler/influxdbhandler/influxdb_handler.go
@@ -242,7 +242,7 @@ func objectToMeasurements(pl handler.DataUpPayload, prefix string, obj interface
 				"application_name": pl.ApplicationName,
 				"device_name":      pl.DeviceName,
 				"dev_eui":          pl.DevEUI.String(),
-				"f_port":           strconv.FormatInt(int64(pl.FPort), 10),
+				"f_port":           strconv.FormatInt(int64(*pl.FPort), 10),
 			},
 			Values: map[string]interface{}{
 				"value": o,
@@ -343,7 +343,7 @@ func mapToLocation(pl handler.DataUpPayload, prefix string, obj reflect.Value) [
 				"application_name": pl.ApplicationName,
 				"device_name":      pl.DeviceName,
 				"dev_eui":          pl.DevEUI.String(),
-				"f_port":           strconv.FormatInt(int64(pl.FPort), 10),
+				"f_port":           strconv.FormatInt(int64(*pl.FPort), 10),
 			},
 			Values: map[string]interface{}{
 				"latitude":  latFloat,
@@ -390,7 +390,7 @@ func structToLocation(pl handler.DataUpPayload, prefix string, obj reflect.Value
 				"application_name": pl.ApplicationName,
 				"device_name":      pl.DeviceName,
 				"dev_eui":          pl.DevEUI.String(),
-				"f_port":           strconv.FormatInt(int64(pl.FPort), 10),
+				"f_port":           strconv.FormatInt(int64(*pl.FPort), 10),
 			},
 			Values: map[string]interface{}{
 				"latitude":  latFloat,

--- a/internal/handler/influxdbhandler/influxdb_handler.go
+++ b/internal/handler/influxdbhandler/influxdb_handler.go
@@ -231,6 +231,13 @@ func (h *Handler) SendErrorNotification(pl handler.ErrorNotification) error {
 	return nil
 }
 
+func valueOrEmptyString(pInt *uint8) string {
+	if pInt != nil {
+		return strconv.FormatInt(int64(*pInt), 10)
+	}
+	return ""
+}
+
 func objectToMeasurements(pl handler.DataUpPayload, prefix string, obj interface{}) []measurement {
 	var out []measurement
 
@@ -242,7 +249,7 @@ func objectToMeasurements(pl handler.DataUpPayload, prefix string, obj interface
 				"application_name": pl.ApplicationName,
 				"device_name":      pl.DeviceName,
 				"dev_eui":          pl.DevEUI.String(),
-				"f_port":           strconv.FormatInt(int64(*pl.FPort), 10),
+				"f_port":           valueOrEmptyString(pl.FPort),
 			},
 			Values: map[string]interface{}{
 				"value": o,
@@ -343,7 +350,7 @@ func mapToLocation(pl handler.DataUpPayload, prefix string, obj reflect.Value) [
 				"application_name": pl.ApplicationName,
 				"device_name":      pl.DeviceName,
 				"dev_eui":          pl.DevEUI.String(),
-				"f_port":           strconv.FormatInt(int64(*pl.FPort), 10),
+				"f_port":           valueOrEmptyString(pl.FPort),
 			},
 			Values: map[string]interface{}{
 				"latitude":  latFloat,
@@ -390,7 +397,7 @@ func structToLocation(pl handler.DataUpPayload, prefix string, obj reflect.Value
 				"application_name": pl.ApplicationName,
 				"device_name":      pl.DeviceName,
 				"dev_eui":          pl.DevEUI.String(),
-				"f_port":           strconv.FormatInt(int64(*pl.FPort), 10),
+				"f_port":           valueOrEmptyString(pl.FPort),
 			},
 			Values: map[string]interface{}{
 				"latitude":  latFloat,

--- a/internal/handler/models.go
+++ b/internal/handler/models.go
@@ -54,7 +54,7 @@ type DataUpPayload struct {
 	RXInfo              []RXInfo      `json:"rxInfo,omitempty"`
 	TXInfo              TXInfo        `json:"txInfo"`
 	FCnt                uint32        `json:"fCnt"`
-	FPort               uint8         `json:"fPort"`
+	FPort               *uint8        `json:"fPort"`
 	Data                []byte        `json:"data"`
 	Object              interface{}   `json:"object,omitempty"`
 }


### PR DESCRIPTION
This allows empty Lora messages (with neither FPort nor payload) to be correctly handled by the app server. See pull request at https://github.com/brocaar/loraserver/pull/329