### PR TITLE
fix: Update MulticastGroupForm.js form helper

### DIFF
--- a/ui/src/views/multicast-groups/MulticastGroupForm.js
+++ b/ui/src/views/multicast-groups/MulticastGroupForm.js
@@ -121,7 +121,7 @@ class MulticastGroupForm extends FormComponent {
             margin="none"
           />
           <FormHelperText>
-            The service-profile to which this application will be attached. Note that you can't change this value after the application has been created.
+            The service-profile to which this multicast-group will be attached. Note that you can't change this value after the multicast-group has been created.
           </FormHelperText>
         </FormControl>}
         <DevAddrField


### PR DESCRIPTION
The FormHelperText associated with a selection box for choosing the Service Profile associated with the Multicast Group is referring to the Application instead of the Multicast Group. This is likely because it was a copy/paste of the FormHelperText of ApplicationForm.js