### PR TITLE
Fixing typo on api docs and config file.

### DIFF
--- a/cmd/lora-app-server/cmd/configfile.go
+++ b/cmd/lora-app-server/cmd/configfile.go
@@ -385,7 +385,7 @@ tls_key="{{ .JoinServer.TLSKey }}"
 
 # Key Encryption Key (KEK) configuration.
 #
-# The KEK meganism is used to encrypt the session-keys sent from the
+# The KEK mechanism is used to encrypt the session-keys sent from the
 # join-server to the network-server.
 #
 # The LoRa App Server join-server will use the NetID of the requesting

--- a/docs/content/install/config.md
+++ b/docs/content/install/config.md
@@ -419,7 +419,7 @@ tls_key=""
 
 # Key Encryption Key (KEK) configuration.
 #
-# The KEK meganism is used to encrypt the session-keys sent from the
+# The KEK mechanism is used to encrypt the session-keys sent from the
 # join-server to the network-server.
 #
 # The LoRa App Server join-server will use the NetID of the requesting

--- a/docs/content/integrate/api.md
+++ b/docs/content/integrate/api.md
@@ -12,7 +12,7 @@ description: Integrate with the LoRa App Server gRCP or RESTful API.
 LoRa App Server provides two API interfaces that can be used to integrate
 with LoRa App Server. Both interfaces provide *exactly* the same
 functionality and [authentication]({{<relref "auth.md">}})
-meganism.
+mechanism.
 
 * [gRPC interface]({{<relref "grpc.md">}})
 * [RESTful JSON interface]({{<relref "rest.md">}})

--- a/docs/content/integrate/auth.md
+++ b/docs/content/integrate/auth.md
@@ -10,7 +10,7 @@ description: Information on API tokens for authentication and authorization.
 # Authentication / authorization
 
 Both the gRPC and the JSON REST interface are protected by an authentication
-and authorization meganism. For this [JSON web-tokens](https://jwt.io) are
+and authorization mechanism. For this [JSON web-tokens](https://jwt.io) are
 used, using the `--jwt-secret` / `JWT_SECRET` value for signing. Therefore
 it is important to choose an unique and strong secret.
 


### PR DESCRIPTION
I found an interesting word that I am not sure if it's a typo. If it's, then this pull request aims to fix it.