### PR TITLE
persist rowsPerPage in localStorage

### DIFF
--- a/ui/src/components/DataTable.js
+++ b/ui/src/components/DataTable.js
@@ -6,6 +6,8 @@ import TableBody from '@material-ui/core/TableBody';
 import TableHead from '@material-ui/core/TableHead';
 import { withStyles } from '@material-ui/core/styles';
 
+import SessionStore from "../stores/SessionStore";
+
 import Paper from "./Paper";
 
 
@@ -20,7 +22,7 @@ class DataTable extends Component {
 
     this.state = {
       count: 0,
-      rowsPerPage: 10,
+      rowsPerPage: SessionStore.getRowsPerPage(),
       page: 0,
       loaded: {
         rows: false,
@@ -57,6 +59,8 @@ class DataTable extends Component {
     this.setState({
       rowsPerPage: event.target.value,
     });
+
+    SessionStore.setRowsPerPage(event.target.value);
 
     this.props.getPage(event.target.value, 0, (result) => {
       this.setState({

--- a/ui/src/stores/SessionStore.js
+++ b/ui/src/stores/SessionStore.js
@@ -57,6 +57,19 @@ class SessionStore extends EventEmitter {
     this.emit("organization.change");
   }
 
+  getRowsPerPage() {
+    const rowsPerPage = localStorage.getItem("rowsPerPage");
+    if (rowsPerPage === "" || rowsPerPage === null) {
+      return 10;
+    }
+
+    return JSON.parse(rowsPerPage);
+  }
+
+  setRowsPerPage(rowsPerPage) {
+    localStorage.setItem("rowsPerPage", JSON.stringify(rowsPerPage));
+  }
+
   getUser() {
     return this.user;
   }


### PR DESCRIPTION
Closes #351 
Persist rowsPerPage on DataTable in localStorage. Maintains the current default of 10 on login.

I wasn't sure if a nonexistent key returned an empty string or null (docs say null), so I tested for both, as you tested for the empty string in getOrganizationID. I've tested this myself and it seems to work fine.